### PR TITLE
Balance tweak 1

### DIFF
--- a/1.4/Defs/ThingsDefs_Misc/Weapons/RangedIndustrial.xml
+++ b/1.4/Defs/ThingsDefs_Misc/Weapons/RangedIndustrial.xml
@@ -487,9 +487,11 @@
     <projectile>
       <speed>40</speed>
       <damageDef>Bomb</damageDef>
-      <damageAmountBase>20</damageAmountBase>
-	  <armorPenetrationBase>0.3</armorPenetrationBase>
-      <explosionRadius>1.9</explosionRadius>
+      <damageAmountBase>30</damageAmountBase>
+	  <armorPenetrationBase>0.15</armorPenetrationBase>
+	  <buildingDamageFactorImpassable>2</buildingDamageFactorImpassable>
+	  <buildingDamageFactorPassable>1.5</buildingDamageFactorPassable>
+      <explosionRadius>2.9</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 	  <ai_IsIncendiary>true</ai_IsIncendiary>
@@ -535,7 +537,7 @@
     <projectile>
       <speed>40</speed>
       <damageDef>Thump</damageDef>
-      <damageAmountBase>10</damageAmountBase>
+      <damageAmountBase>25</damageAmountBase>
       <explosionRadius>1.9</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>

--- a/FoxysArmory/1.4/Defs/ThingDefs_Misc/Weapons/Eccentric_Launchers.xml
+++ b/FoxysArmory/1.4/Defs/ThingDefs_Misc/Weapons/Eccentric_Launchers.xml
@@ -504,9 +504,11 @@ Things/Eccentric/Ammo/CGL/Smoke/Smoke_c
     <projectile>
       <speed>80</speed>
       <damageDef>Bomb</damageDef>
-      <damageAmountBase>30</damageAmountBase>
-	  <armorPenetrationBase>0.45</armorPenetrationBase>
-      <explosionRadius>2.9</explosionRadius>
+      <damageAmountBase>45</damageAmountBase>
+	  <armorPenetrationBase>0.3</armorPenetrationBase>
+	  <buildingDamageFactorImpassable>2</buildingDamageFactorImpassable>
+	  <buildingDamageFactorPassable>1.5</buildingDamageFactorPassable>
+      <explosionRadius>3.9</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 	  <ai_IsIncendiary>true</ai_IsIncendiary>
@@ -552,7 +554,7 @@ Things/Eccentric/Ammo/CGL/Smoke/Smoke_c
     <projectile>
       <speed>80</speed>
       <damageDef>Thump</damageDef>
-      <damageAmountBase>15</damageAmountBase>
+      <damageAmountBase>35</damageAmountBase>
       <explosionRadius>2.9</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>


### PR DESCRIPTION
Increase explosive damage and radius, decrease armor penetration and building damage multiplier, it's more of a frag grenade now.
Increase thump damage, still pretty effective even if Thump Cannon Nerf is installed.